### PR TITLE
Fix syntax error in types_generator.rb

### DIFF
--- a/types-generator/lib/types_generator.rb
+++ b/types-generator/lib/types_generator.rb
@@ -104,4 +104,3 @@ class TypesGenerator
     end
   end
 end
-end

--- a/types-generator/lib/types_generator.rb
+++ b/types-generator/lib/types_generator.rb
@@ -57,8 +57,8 @@ class TypesGenerator
       extends = extends(object[:type])
       returnType = page.xpath("//table[@class='memberdecls']/tr[starts-with(@class, 'memitem')]/td[@class='memItemRight']/b[text()='ReturnType']")
                        .first&.parent&.xpath("a[@class='el']")&.last&.text if object[:type] == "function"
-      object.merge(returnType:) if returnType
-      object.merge(fields:, extends:)
+      object.merge!(returnType: returnType) if returnType
+      object.merge!(fields: fields, extends: extends)
     end
 
     def fields(fields_table)
@@ -103,4 +103,5 @@ class TypesGenerator
       end
     end
   end
+end
 end


### PR DESCRIPTION
Fix syntax errors in `types-generator/lib/types_generator.rb`:

* Replace `object.merge(returnType:)` with `object.merge!(returnType: returnType)` on line 60.
* Replace `object.merge(fields:, extends:)` with `object.merge!(fields: fields, extends: extends)` on line 61.
* Add `end` at the end of the file.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/oott123/tdlib-json-cli?shareId=92d75107-d435-43f3-b955-15feed315efd).